### PR TITLE
Fix Turing's burn-in samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.jl.cov
 *.jl.*.cov
 *.jl.mem

--- a/src/MCMCBenchmarks.jl
+++ b/src/MCMCBenchmarks.jl
@@ -151,7 +151,8 @@ Runs the benchmarking procedure and returns the results
      compile(samplers,simulate;kwargs...)
      pfun(rep) = benchmark(samplers,simulate,rep,chains;kwargs...)
      reps = setreps(Nreps)
-     presults = pmap(rep->pfun(rep),reps)
+    #  presults = pmap(rep->pfun(rep),reps)
+     presults = map(rep->pfun(rep),reps)
      return vcat(presults...,cols=:union)
  end
 
@@ -162,7 +163,7 @@ parameter estimation
 * `data`: data for benchmarking
 """
 function runSampler(s::AHMCNUTS,data;kwargs...)
-    return sample(s.model(data...),s.config)
+    return sample(s.model(data...),s.config; discard_adapt=false)
 end
 
 function runSampler(s::DNNUTS,data;kwargs...)
@@ -189,7 +190,7 @@ update results on each iteration
 function updateResults!(s::AHMCNUTS,performance,results;kwargs...)
     chain = performance[1]
     newDF = DataFrame()
-    # chain=removeBurnin(chain;kwargs...)
+    chain=removeBurnin(chain;kwargs...)
     df = describe(chain)[1].df
     addColumns!(newDF,chain,df,:ess)
     addColumns!(newDF,chain,df,:r_hat)

--- a/src/MCMCBenchmarks.jl
+++ b/src/MCMCBenchmarks.jl
@@ -189,7 +189,7 @@ update results on each iteration
 function updateResults!(s::AHMCNUTS,performance,results;kwargs...)
     chain = performance[1]
     newDF = DataFrame()
-    chain=removeBurnin(chain;kwargs...)
+    # chain=removeBurnin(chain;kwargs...)
     df = describe(chain)[1].df
     addColumns!(newDF,chain,df,:ess)
     addColumns!(newDF,chain,df,:r_hat)

--- a/src/MCMCBenchmarks.jl
+++ b/src/MCMCBenchmarks.jl
@@ -151,8 +151,7 @@ Runs the benchmarking procedure and returns the results
      compile(samplers,simulate;kwargs...)
      pfun(rep) = benchmark(samplers,simulate,rep,chains;kwargs...)
      reps = setreps(Nreps)
-    #  presults = pmap(rep->pfun(rep),reps)
-     presults = map(rep->pfun(rep),reps)
+     presults = pmap(rep->pfun(rep),reps)
      return vcat(presults...,cols=:union)
  end
 


### PR DESCRIPTION
The current release of Turing will not return burn-in samples by default. This PR set Turing to return them so that it's consistent with other samplers.